### PR TITLE
Fixed des.c failing to compile on some compilers, fixes #2

### DIFF
--- a/des.c
+++ b/des.c
@@ -250,14 +250,14 @@ void des_crypt(const BYTE in[], BYTE out[], const BYTE key[][6])
 void three_des_key_setup(const BYTE key[], BYTE schedule[][16][6], DES_MODE mode)
 {
 	if (mode == DES_ENCRYPT) {
-		des_key_setup(&key[0],schedule[0],mode);
-		des_key_setup(&key[8],schedule[1],!mode);
-		des_key_setup(&key[16],schedule[2],mode);
+		des_key_setup(&key[0],schedule[0],DES_ENCRYPT);
+		des_key_setup(&key[8],schedule[1],DES_DECRYPT);
+		des_key_setup(&key[16],schedule[2],DES_ENCRYPT);
 	}
 	else /*if (mode == DES_DECRYPT*/ {
-		des_key_setup(&key[16],schedule[0],mode);
-		des_key_setup(&key[8],schedule[1],!mode);
-		des_key_setup(&key[0],schedule[2],mode);
+		des_key_setup(&key[16],schedule[0],DES_DECRYPT);
+		des_key_setup(&key[8],schedule[1],DES_ENCRYPT);
+		des_key_setup(&key[0],schedule[2],DES_DECRYPT);
 	}
 }
 


### PR DESCRIPTION
Some compilers cast `mode` to a bool when inverted with `!`, this fixes it by changing the modes for each step of 3DES to be hard-coded to their correct values.
