### PR TITLE
Fixed arcfour.c initializing variables it wasn't supposed to, fixes #1

### DIFF
--- a/arcfour.c
+++ b/arcfour.c
@@ -32,11 +32,12 @@ void arcfour_key_setup(BYTE state[], const BYTE key[], int len)
 // stream starting from the first  output byte.
 void arcfour_generate_stream(BYTE state[], BYTE out[], size_t len)
 {
-	int i, j;
+	int i = 0;
+	int j = 0;
 	size_t idx;
 	BYTE t;
 
-	for (idx = 0, i = 0, j = 0; idx < len; ++idx)  {
+	for (idx = 0; idx < len; ++idx)  {
 		i = (i + 1) % 256;
 		j = (j + state[i]) % 256;
 		t = state[i];


### PR DESCRIPTION
The function `arcfour_generate_stream` in `arcfour.c` set the `i` and `j` variables back to 0 at the start of every iteration of the for loop, while they're only supposed to be initialized to 0 at the start of the function and stay the same between iterations, as seen [here](https://en.wikipedia.org/wiki/RC4#Pseudo-random_generation_algorithm_.28PRGA.29).
