### PR TITLE
sha256: Use standard types uint8_t / uint32_t so types doesn't have to be adjusted manually

### DIFF
--- a/sha256.h
+++ b/sha256.h
@@ -11,13 +11,14 @@
 
 /*************************** HEADER FILES ***************************/
 #include <stddef.h>
+#include <stdint.h>
 
 /****************************** MACROS ******************************/
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
 
 /**************************** DATA TYPES ****************************/
-typedef unsigned char BYTE;             // 8-bit byte
-typedef unsigned int  WORD;             // 32-bit word, change to "long" for 16-bit machines
+typedef uint8_t   BYTE;             // 8-bit byte
+typedef uint32_t  WORD;             // 32-bit word
 
 typedef struct {
 	BYTE data[64];


### PR DESCRIPTION
This makes the code more portable. you can use the same code both on a pc and on a embedded system.

if you do not like to use uint8_t and uint32_t for some reason then I would suggest that we use preprocessor to select proper types. Something like:

    #if sizeof(int) == 4
    typedef unsigned int WORD;
    elif sizeof(long) == 4
    typedef unsigned long WORD;
    #else
    #error WORD type not configured properly
    #endif
