### PR TITLE
sha256: fix undefined behavior in left shift of BYTE by 24

### DIFF
--- a/sha256.c
+++ b/sha256.c
@@ -46,7 +46,7 @@ void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
 	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
 	for (i = 0, j = 0; i < 16; ++i, j += 4)
-		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+		m[i] = ((WORD)data[j] << 24) | ((WORD)data[j + 1] << 16) | ((WORD)data[j + 2] << 8) | ((WORD)data[j + 3]);
 	for ( ; i < 64; ++i)
 		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
 


### PR DESCRIPTION
In `sha256_transform`, the expression `data[j] << 24` promotes the `BYTE` (`unsigned char`) operand to `int` (signed 32-bit) before shifting. When `data[j] >= 128`, shifting by 24 produces a value that cannot be represented in a signed 32-bit int, which is undefined behavior per the C standard (C11 6.5.7p4).

Found by UndefinedBehaviorSanitizer:

```
sha256.c:49:19: runtime error: left shift of 128 by 24 places
cannot be represented in type 'int'
```

Fix: cast each `BYTE` to `WORD` (`unsigned int`) before shifting. This ensures the shift operates on unsigned 32-bit values, which is well-defined for all byte values.

The fix is a single line change with no behavioral difference for correct inputs (the UB happened to produce the correct result on all common platforms, but relying on UB is not portable).